### PR TITLE
Added alias option and fixed some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ var output = importResolve({
         console.log('did it myself.');
     });
 });
+
+// You can pass alias if you have some files which have alias in your build process
+importResolve({
+    "ext": "less",
+    "pathToMain": "path/to/main.less",
+    "output": "path/to/output.less",
+    "alias": {
+        "~myUniqueAlias": "path/to/unique/file.less"
+    }
+});
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var fs = require('fs'),
     regex = /@import[^'"]+?['"](.+?)['"];?/g;
 
 function ImportResolver (opts) {
-    this.cwd = '';
     this.dist = '';
     this.output = opts.output;
     this.alias = opts.alias || {};
@@ -65,7 +64,7 @@ ImportResolver.prototype.read = function (filename) {
     if (path.isAbsolute(filename)) {
       filenameWithPath = filename;
     } else {
-      filenameWithPath = path.join(this.root, this.cwd, filename);
+      filenameWithPath = path.join(this.root, filename);
     }
 
     filenameWithPathAndExtension = this.trimExtension(filenameWithPath) + this.ext;

--- a/tests/less/alias.less
+++ b/tests/less/alias.less
@@ -1,0 +1,1 @@
+@import '~myAlias';


### PR DESCRIPTION
* Import to absolute paths fixed.
* Import to files without extension but has a `.` in file name fixed (for example `bla.bloop` should import `bla.bloop.ext` instead of `bla.ext`).
* Added `alias` property, when your build process has alias', then you can set alias too (added example in `README.md`).   

Tests been failing even before I started so I didn't bother.
Waiting for it to be on npm and thanks in advance! 