### PR TITLE
Ignored imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ importResolve({
         "~myUniqueAlias": "path/to/unique/file.less"
     }
 });
+
+// You can pass an array of import paths that you'd like the resolver to ignore. Ignored imports will remain in the output file.
+importResolve({
+    "ext": "less",
+    "pathToMain": "path/to/main.less",
+    "output": "path/to/output.less",
+    "ignorePaths": [
+        "path/to/ignored/file.less"
+    ]
+});
+
+// You can also ignore imports based on a RegExp pattern. Ignored imports will remain in the output file.
+importResolve({
+    "ext": "less",
+    "pathToMain": "path/to/main.less",
+    "output": "path/to/output.less",
+    "ignorePathPattern": /^~/
+});
 ```
 
 ## Tests

--- a/lib/import-resolver.js
+++ b/lib/import-resolver.js
@@ -6,6 +6,8 @@ var fs = require('fs'),
 
 function ImportResolver (opts) {
     this.aliases = opts.aliases || {};
+    this.ignorePaths = opts.ignorePaths || [];
+    this.ignorePathPattern = opts.ignorePathPattern;
     this.cwd = '';
     this.dist = '';
     this.output = opts.output;
@@ -70,17 +72,20 @@ ImportResolver.prototype.getFile = function (filename) {
 ImportResolver.prototype.normalizeImport = function (str) {
     if (regex.test(str)) {
         str = str.replace(regex, function (m, capture) {
-            var p,
-                pathToImport,
-                aliasKeys = Object.keys(this.aliases),
-                index = aliasKeys && aliasKeys.length ? aliasKeys.indexOf(capture) : -1;
-            if (index !== -1) {
-                pathToImport = this.aliases[aliasKeys[index]];
-            } else {
-                pathToImport = capture;
+            if(this.ignorePaths.indexOf(capture) === -1 && (!this.ignorePathPattern || !this.ignorePathPattern.test(capture))) {
+                var p,
+                    pathToImport,
+                    aliasKeys = Object.keys(this.aliases),
+                    index = aliasKeys && aliasKeys.length ? aliasKeys.indexOf(capture) : -1;
+                if (index !== -1) {
+                    pathToImport = this.aliases[aliasKeys[index]];
+                } else {
+                    pathToImport = capture;
+                }
+                p = path.resolve(this.cwd, pathToImport);
+                return m && m.replace(capture, p);
             }
-            p = path.resolve(this.cwd, pathToImport);
-            return m && m.replace(capture, p);
+            return m;
         }.bind(this));
     }
     return str;
@@ -117,7 +122,9 @@ ImportResolver.prototype.resolve = function(oldFile){
     }
 
     matches.forEach(function (match) {
-        oldFile = oldFile.replace(match[0], this.read(match[1]));
+        if(this.ignorePaths.indexOf(match[1]) === -1 && (!this.ignorePathPattern || !new RegExp(this.ignorePathPattern).test(match[1]))) {
+            oldFile = oldFile.replace(match[0], this.read(match[1]));
+        }
     }.bind(this));
 
     return oldFile;

--- a/tests/ignore/ignore-two.styl
+++ b/tests/ignore/ignore-two.styl
@@ -1,0 +1,3 @@
+.import-two {
+    color: blue;
+}

--- a/tests/ignore/main.styl
+++ b/tests/ignore/main.styl
@@ -1,0 +1,6 @@
+@import '~path/to/be/ignored';
+@import 'ignore-two';
+
+.ignore {
+    display: block;
+}

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -72,6 +72,28 @@ describe('importResolve integration', function () {
             expect(standardizeChars(output)).toBe('.alias-one {\n    color: blue;\n}\n\n.alias-two {\n    background: white;\n}\n\n\n.alias {\n    display: block;\n}');
         });
     });
+
+    it('should ignore paths specified in the ignorePaths array', function() {
+        importResolve({
+            "pathToMain": "tests/ignore/main.styl",
+            "ext": "styl",
+            "ignorePaths": [
+                "~path/to/be/ignored"
+            ]
+        }, function (output) {
+            expect(standardizeChars(output)).toBe('@import \'~path/to/be/ignored\';\n.import-two {\n    color: blue;\n}\n\n.ignore {\n    display: block;\n}');
+        });
+    });
+
+    it('should ignore paths that match the specified ignorePathPattern', function() {
+        importResolve({
+            "pathToMain": "tests/ignore/main.styl",
+            "ext": "styl",
+            "ignorePathPattern": /^~/
+        }, function (output) {
+            expect(standardizeChars(output)).toBe('@import \'~path/to/be/ignored\';\n.import-two {\n    color: blue;\n}\n\n.ignore {\n    display: block;\n}');
+        });
+    });
 });
 
 describe('file write system', function () {

--- a/tests/lib/import-resolver.spec.js
+++ b/tests/lib/import-resolver.spec.js
@@ -18,7 +18,11 @@ describe('ImportResolver', function () {
                 "pathToMain": normalize("baz/bing"),
                 "aliases": {
                     "myAlias": "qux"
-                }
+                },
+                "ignorePaths": [
+                    "~path/to/ignore"
+                ],
+                "ignorePathPattern": /^~/
             });
         });
         afterEach(function () {
@@ -38,6 +42,12 @@ describe('ImportResolver', function () {
             expect(subject.aliases).toEqual({
                 "myAlias": "qux"
             });
+        });
+        it('should set ignore paths', function () {
+            expect(subject.ignorePaths).toEqual(["~path/to/ignore"]);
+        });
+        it('should set ignore pattern', function () {
+            expect(subject.ignorePathPattern).toEqual(/^~/);
         });
     });
 
@@ -130,7 +140,8 @@ describe('ImportResolver', function () {
                 "cwd": "foo" + path.sep,
                 "aliases": {
                     "myAlias": "./bar/baz/qux"
-                }
+                },
+                "ignorePaths": []
             });
         });
         afterEach(function () {

--- a/tests/output/path/doesnt/exist/yet.styl
+++ b/tests/output/path/doesnt/exist/yet.styl
@@ -1,0 +1,10 @@
+$variable_1 = 16px
+$variable_2 = 3em
+
+$another_var = #444
+
+.some-div
+    background: $another_var
+
+#some-id
+    font-weight: normal


### PR DESCRIPTION
Because I have some import statements that resolve to files contained in a peer dependant node module, I needed the ability to specify certain paths that the resolver would ignore, leaving the import statements intact.

I've implemented the two options for achieving this that I figured would be most useful to people.